### PR TITLE
get_tickers_list method won't work. A proposal.

### DIFF
--- a/src/pycocos/components/client.py
+++ b/src/pycocos/components/client.py
@@ -323,11 +323,11 @@ class RestClient:
         """
         return self.api_request(
             urls.endpoints["tickers_list"].format(
-                instrument_type,
-                instrumet_subtype,
-                settlement,
-                currency,
-                segment,
+                instrument_type.value,
+                instrumet_subtype.value,
+                settlement.value,
+                currency.value,
+                segment.value,
             )
         )
 

--- a/src/pycocos/components/enums.py
+++ b/src/pycocos/components/enums.py
@@ -74,6 +74,7 @@ class InstrumentSubType(Enum):
     PROV = "PROVINCIALES"
     TOP = "TOP"
     USD = "NACIONALES_USD"
+    BONOS_CORP = "BONOSC"
 
 
 class Settlement(Enum):


### PR DESCRIPTION
#Problem
I was trying to scrap the corporate bonds information, but the `get_tickers_list` method won't work because of an `ApiException: Bad HTTP API Response` was raised. This is an example for "acciones líderes":

```
app.client.get_tickers_list(
    app.instrument_types.ACCIONES,
    app.instrument_subtypes.LIDERES,
    app.settlements.T2,
    app.currencies.USD,
    app.segments.DEFAULT
)
```
For the specific case of corporate bonds, I had to add a new `InstrumentSubType` that was not included. It is a shame that the endpoint "types" does not exist anymore.

![image](https://github.com/nacho-herrera/pyCocos/assets/70729951/7dd4f1fc-8383-49ac-a657-18c26020b119)

Nevertheless, the problem is still there.

# Suggestion
I could correct the issue when I called for the value in the enumeration required in the `get_tickers_list` method. Instead of receiving a string as an input, it was an `<enum>`. Take into account that I am no expert, and in consequence, I do not know if it is the best solution. Besides that, I wanted to share the issue and a proposal.

![image](https://github.com/nacho-herrera/pyCocos/assets/70729951/7017230c-7a43-4a19-a9f3-eae9bac39665)

Thank you so much for the work you've done up to know. It is really useful to me. I've learned a lot from you.